### PR TITLE
Properly implement abstract base classes and change ThrowEffect implementation

### DIFF
--- a/Assets/Scripts/Character.cs
+++ b/Assets/Scripts/Character.cs
@@ -1,0 +1,40 @@
+using UnityEngine.UI;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum CharacterChoice { Buster }
+
+public abstract class Character
+{
+    protected string name;
+    private Slider healthSlider;
+    private readonly int maxHp = 6;
+    private int _hp;
+    private int hp
+    {
+        get { return _hp; }
+        set { _hp = value; healthSlider.value = value; }
+    }
+    public List<Throw> throws { get; private set; } = new List<Throw>();
+
+    public Character(Player p_player, Player p_opponent, RectTransform myUI)
+    {
+        _hp = maxHp;
+        ConfigureThrows(p_player, p_opponent);
+        ConfigureBaseUI(myUI);
+        ConfigureCharacterUI(myUI);
+    }
+
+    private void ConfigureBaseUI(RectTransform myUI)
+    {
+        healthSlider = myUI.Find("Health Bar/Health Slider")
+            .GetComponent<Slider>();
+        healthSlider.maxValue = maxHp;
+        healthSlider.value = maxHp;
+    }
+
+    public bool isAlive() { return hp > 0; }
+    public void Damage(int damage) { hp = hp < damage ? 0 : hp - damage; }
+    protected virtual void ConfigureCharacterUI(RectTransform myUI) { }
+    protected abstract void ConfigureThrows(Player p_player, Player p_opponent);
+}

--- a/Assets/Scripts/Character.cs.meta
+++ b/Assets/Scripts/Character.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ba8af4ac28704e2b9b3b9a4ef4b2fed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Characters.meta
+++ b/Assets/Scripts/Characters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b62a3a2fc3f942cfbc328b288a184c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Characters/CharBuster.cs
+++ b/Assets/Scripts/Characters/CharBuster.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 
-public class CharBuster : Character {
+public class CharBuster : Character
+{
     public CharBuster(Player p_player, Player p_opponent, RectTransform myUI) :
         base(p_player, p_opponent, myUI)
     {

--- a/Assets/Scripts/Characters/CharBuster.cs
+++ b/Assets/Scripts/Characters/CharBuster.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+public class CharBuster : Character {
+    public CharBuster(Player p_player, Player p_opponent, RectTransform myUI) :
+        base(p_player, p_opponent, myUI)
+    {
+        name = "Buster";
+    }
+
+    protected override void ConfigureThrows(Player p_player, Player p_opponent)
+    {
+        throws.Add(new Throw_DefaultRock(p_player, p_opponent));
+        throws.Add(new Throw_DefaultPaper(p_player, p_opponent));
+        throws.Add(new Throw_DefaultScissors(p_player, p_opponent));
+    }
+}

--- a/Assets/Scripts/Characters/CharBuster.cs.meta
+++ b/Assets/Scripts/Characters/CharBuster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0edfa84ab340848cab4c1495123243bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Characters/CommonThrows.cs
+++ b/Assets/Scripts/Characters/CommonThrows.cs
@@ -2,37 +2,39 @@
 // characters.
 
 // THROWS
-class Throw_DefaultRock : Throw 
+class Throw_DefaultRock : Throw
 {
     public Throw_DefaultRock(Player player, Player opponent)
-        : base( player, opponent ) {}
-    protected override string SetName(){ return "Default Rock"; }
-    protected override ThrowType SetThrowType(){ return ThrowType.Rock; }
+        : base(player, opponent) { }
+    protected override string SetName() { return "Default Rock"; }
+    protected override ThrowType SetThrowType() { return ThrowType.Rock; }
     protected override void addThrowEffects(Player p_player, Player p_opponent)
     {
-        throwEffects.Add( new TEffect_DmgOnWin( p_player, p_opponent, 1) );
+        throwEffects.Add(new TEffect_DmgOnWin(p_player, p_opponent, 1));
     }
 }
 
-class Throw_DefaultPaper : Throw {
+class Throw_DefaultPaper : Throw
+{
     public Throw_DefaultPaper(Player player, Player opponent)
-        : base( player, opponent ) {}
-    protected override string SetName(){ return "Default Paper"; }
-    protected override ThrowType SetThrowType(){ return ThrowType.Paper; }
+        : base(player, opponent) { }
+    protected override string SetName() { return "Default Paper"; }
+    protected override ThrowType SetThrowType() { return ThrowType.Paper; }
     protected override void addThrowEffects(Player p_player, Player p_opponent)
     {
-        throwEffects.Add( new TEffect_DmgOnWin( p_player, p_opponent, 1) );
+        throwEffects.Add(new TEffect_DmgOnWin(p_player, p_opponent, 1));
     }
 }
 
-class Throw_DefaultScissors : Throw {
+class Throw_DefaultScissors : Throw
+{
     public Throw_DefaultScissors(Player player, Player opponent)
-        : base( player, opponent ) {}
-    protected override string SetName(){ return "Default Scissors"; }
-    protected override ThrowType SetThrowType(){ return ThrowType.Scissors; }
+        : base(player, opponent) { }
+    protected override string SetName() { return "Default Scissors"; }
+    protected override ThrowType SetThrowType() { return ThrowType.Scissors; }
     protected override void addThrowEffects(Player p_player, Player p_opponent)
     {
-        throwEffects.Add( new TEffect_DmgOnWin( p_player, p_opponent, 1) );
+        throwEffects.Add(new TEffect_DmgOnWin(p_player, p_opponent, 1));
     }
 }
 
@@ -45,7 +47,7 @@ public class TEffect_DmgOnWin : ThrowEffect
     public TEffect_DmgOnWin(
             Player p_player,
             Player p_opponent,
-            int p_damage) : base( p_player, p_opponent )
+            int p_damage) : base(p_player, p_opponent)
     {
         damage = p_damage;
     }

--- a/Assets/Scripts/Characters/CommonThrows.cs
+++ b/Assets/Scripts/Characters/CommonThrows.cs
@@ -1,0 +1,54 @@
+// This script contains throws and throweffects that are used across one or more
+// characters.
+
+// THROWS
+class Throw_DefaultRock : Throw 
+{
+    public Throw_DefaultRock(Player player, Player opponent)
+        : base( player, opponent ) {}
+    protected override string SetName(){ return "Default Rock"; }
+    protected override ThrowType SetThrowType(){ return ThrowType.Rock; }
+    protected override void addThrowEffects(Player p_player, Player p_opponent)
+    {
+        throwEffects.Add( new TEffect_DmgOnWin( p_player, p_opponent, 1) );
+    }
+}
+
+class Throw_DefaultPaper : Throw {
+    public Throw_DefaultPaper(Player player, Player opponent)
+        : base( player, opponent ) {}
+    protected override string SetName(){ return "Default Paper"; }
+    protected override ThrowType SetThrowType(){ return ThrowType.Paper; }
+    protected override void addThrowEffects(Player p_player, Player p_opponent)
+    {
+        throwEffects.Add( new TEffect_DmgOnWin( p_player, p_opponent, 1) );
+    }
+}
+
+class Throw_DefaultScissors : Throw {
+    public Throw_DefaultScissors(Player player, Player opponent)
+        : base( player, opponent ) {}
+    protected override string SetName(){ return "Default Scissors"; }
+    protected override ThrowType SetThrowType(){ return ThrowType.Scissors; }
+    protected override void addThrowEffects(Player p_player, Player p_opponent)
+    {
+        throwEffects.Add( new TEffect_DmgOnWin( p_player, p_opponent, 1) );
+    }
+}
+
+// THROW EFFECTS
+
+public class TEffect_DmgOnWin : ThrowEffect
+{
+    private int damage;
+
+    public TEffect_DmgOnWin(
+            Player p_player,
+            Player p_opponent,
+            int p_damage) : base( p_player, p_opponent )
+    {
+        damage = p_damage;
+    }
+
+    protected override void OnWin() { opponent.character.Damage(damage); }
+}

--- a/Assets/Scripts/Characters/CommonThrows.cs.meta
+++ b/Assets/Scripts/Characters/CommonThrows.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2ba40dc02bda4d85bf90d5c1cbbd393
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -15,7 +15,7 @@ public class Player : MonoBehaviour
         victoryCrown = characterUI.Find("Victory Crown").GetComponent<Image>();
     }
 
-    public void Reset( CharacterChoice p_char, Player opponent,
+    public void Reset(CharacterChoice p_char, Player opponent,
             bool isWinner = false)
     {
         switch (p_char)

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using UnityEngine.UI;
-using System.Collections.Generic;
 
 public class Player : MonoBehaviour
 {
@@ -10,64 +9,22 @@ public class Player : MonoBehaviour
     [HideInInspector] public Character character { get; private set; }
     [HideInInspector] public Throw selectedThrow;
     private Image victoryCrown;
-    public enum CharacterChoice { Buster }
 
     void Start()
     {
         victoryCrown = characterUI.Find("Victory Crown").GetComponent<Image>();
     }
 
-    public void Reset(
-            CharacterChoice p_char,
-            Player opponent,
+    public void Reset( CharacterChoice p_char, Player opponent,
             bool isWinner = false)
     {
         switch (p_char)
         {
             case CharacterChoice.Buster:
-                character = new Character(this, opponent, characterUI);
+                character = new CharBuster(this, opponent, characterUI);
                 break;
         }
         victoryCrown.enabled = isWinner;
     }
 }
 
-public class Character
-{
-    private Slider healthSlider;
-    private readonly string name = "Buster";
-    private readonly int maxHp = 6;
-    private int _hp;
-    private int hp
-    {
-        get { return _hp; }
-        set { _hp = value; healthSlider.value = value; }
-    }
-    public List<Throw> throws { get; private set; } = new List<Throw>();
-
-    public Character(Player p_player, Player p_opponent, RectTransform myUI)
-    {
-        _hp = maxHp;
-        ConfigureThrows(p_player, p_opponent);
-        ConfigureUI(myUI);
-    }
-
-    private void ConfigureThrows(Player p_player, Player p_opponent)
-    {
-        throws.Add(new Throw(Throw.ThrowType.Rock, p_player, p_opponent));
-        throws.Add(new Throw(Throw.ThrowType.Paper, p_player, p_opponent));
-        throws.Add(new Throw(Throw.ThrowType.Scissors, p_player, p_opponent));
-    }
-
-    private void ConfigureUI(RectTransform myUI)
-    {
-        healthSlider = myUI.Find("Health Bar/Health Slider")
-            .GetComponent<Slider>();
-        healthSlider.maxValue = maxHp;
-        healthSlider.value = maxHp;
-    }
-
-    public bool isAlive() { return hp > 0; }
-
-    public void Damage(int damage) { hp = hp < damage ? 0 : hp - damage; }
-}

--- a/Assets/Scripts/RPKManager.cs
+++ b/Assets/Scripts/RPKManager.cs
@@ -12,39 +12,41 @@ public class RPKManager : MonoBehaviour
 
     void Start()
     {
-        player1.Reset( CharacterChoice.Buster, player2 );
-        player2.Reset( CharacterChoice.Buster, player1 );
+        player1.Reset(CharacterChoice.Buster, player2);
+        player2.Reset(CharacterChoice.Buster, player1);
         roundCounter.text = "Throw #: 1";
     }
 
     void Update()
     {
-        if(player1.selectedThrow != null && player2.selectedThrow != null)
+        if (player1.selectedThrow != null && player2.selectedThrow != null)
         {
-            Throw.ResolveThrow( player1.selectedThrow, player2.selectedThrow );
+            Throw.ResolveThrow(player1.selectedThrow, player2.selectedThrow);
             player1.selectedThrow = null;
             player2.selectedThrow = null;
             throwCounter++;
-            if(!player1.character.isAlive()){
+            if (!player1.character.isAlive())
+            {
                 throwCounter = 1;
-                player1.Reset( CharacterChoice.Buster, player2, false );
-                player2.Reset( CharacterChoice.Buster, player1, true );
+                player1.Reset(CharacterChoice.Buster, player2, false);
+                player2.Reset(CharacterChoice.Buster, player1, true);
             }
-            if(!player2.character.isAlive()){
+            if (!player2.character.isAlive())
+            {
                 throwCounter = 1;
-                player1.Reset( CharacterChoice.Buster, player1, true );
-                player2.Reset( CharacterChoice.Buster, player2, false );
+                player1.Reset(CharacterChoice.Buster, player1, true);
+                player2.Reset(CharacterChoice.Buster, player2, false);
             }
-            roundCounter.text = string.Format( "Throw #: {0}", throwCounter );
+            roundCounter.text = string.Format("Throw #: {0}", throwCounter);
         }
     }
 
     public void throwSelection(int throwNumber)
     {
-        if( throwNumber > 0)
-            player1.selectedThrow = player1.character.throws[throwNumber-1];
+        if (throwNumber > 0)
+            player1.selectedThrow = player1.character.throws[throwNumber - 1];
         else
-            player2.selectedThrow = player2.character.throws[Mathf.Abs(throwNumber)-1];
+            player2.selectedThrow = player2.character.throws[Mathf.Abs(throwNumber) - 1];
     }
 }
 

--- a/Assets/Scripts/RPKManager.cs
+++ b/Assets/Scripts/RPKManager.cs
@@ -12,8 +12,8 @@ public class RPKManager : MonoBehaviour
 
     void Start()
     {
-        player1.Reset( Player.CharacterChoice.Buster, player2 );
-        player2.Reset( Player.CharacterChoice.Buster, player1 );
+        player1.Reset( CharacterChoice.Buster, player2 );
+        player2.Reset( CharacterChoice.Buster, player1 );
         roundCounter.text = "Throw #: 1";
     }
 
@@ -27,13 +27,13 @@ public class RPKManager : MonoBehaviour
             throwCounter++;
             if(!player1.character.isAlive()){
                 throwCounter = 1;
-                player1.Reset( Player.CharacterChoice.Buster, player2, false );
-                player2.Reset( Player.CharacterChoice.Buster, player1, true );
+                player1.Reset( CharacterChoice.Buster, player2, false );
+                player2.Reset( CharacterChoice.Buster, player1, true );
             }
             if(!player2.character.isAlive()){
                 throwCounter = 1;
-                player1.Reset( Player.CharacterChoice.Buster, player1, true );
-                player2.Reset( Player.CharacterChoice.Buster, player2, false );
+                player1.Reset( CharacterChoice.Buster, player1, true );
+                player2.Reset( CharacterChoice.Buster, player2, false );
             }
             roundCounter.text = string.Format( "Throw #: {0}", throwCounter );
         }

--- a/Assets/Scripts/Throw.cs
+++ b/Assets/Scripts/Throw.cs
@@ -1,44 +1,46 @@
 using System.Collections.Generic;
-using System;
 
-public class Throw
+public enum ThrowType { Rock, Paper, Scissors }
+public enum ThrowOutcome { Won, Lost, Clashed }
+
+public abstract class Throw
 {
-    public enum ThrowType { Rock, Paper, Scissors }
-    public enum ThrowOutcome { Won, Lost, Clashed }
-
     public string name { get; private set; }
-    public event EventHandler<ThrowOutcome> handler;
     public List<ThrowEffect> throwEffects = new List<ThrowEffect>();
-    private ThrowType throwType;
+    protected ThrowType throwType;
+    protected abstract string SetName();
+    protected abstract ThrowType SetThrowType();
+    protected abstract void addThrowEffects(Player p_player, Player p_opponent);
 
-    public Throw(ThrowType p_throwType, Player p_player, Player p_opponent)
+    public Throw(Player p_player, Player p_opponent)
     {
-        name = "Default " + p_throwType.ToString();
-        throwType = p_throwType;
+        name = SetName();
+        throwType = SetThrowType();
         addThrowEffects(p_player, p_opponent);
-    }
-
-    public virtual void addThrowEffects(Player p_player, Player p_opponent)
-    {
-        throwEffects.Add(new TEffectDmgOnWin(ref handler, p_opponent, 1));
     }
 
     public static void ResolveThrow(Throw a, Throw b)
     {
         if (a.Equals(b))
         {
-            a.handler?.Invoke(a, ThrowOutcome.Clashed);
-            b.handler?.Invoke(b, ThrowOutcome.Clashed);
+            foreach (ThrowEffect throwEffect in a.throwEffects)
+                throwEffect.Execute(ThrowOutcome.Clashed);
+            foreach (ThrowEffect throwEffect in b.throwEffects)
+                throwEffect.Execute(ThrowOutcome.Clashed);
         }
         else if (a > b)
         {
-            a.handler?.Invoke(a, ThrowOutcome.Won);
-            b.handler?.Invoke(b, ThrowOutcome.Lost);
+            foreach (ThrowEffect throwEffect in a.throwEffects)
+                throwEffect.Execute(ThrowOutcome.Won);
+            foreach (ThrowEffect throwEffect in b.throwEffects)
+                throwEffect.Execute(ThrowOutcome.Lost);
         }
         else
         {
-            a.handler?.Invoke(a, ThrowOutcome.Lost);
-            b.handler?.Invoke(b, ThrowOutcome.Won);
+            foreach (ThrowEffect throwEffect in a.throwEffects)
+                throwEffect.Execute(ThrowOutcome.Lost);
+            foreach (ThrowEffect throwEffect in b.throwEffects)
+                throwEffect.Execute(ThrowOutcome.Won);
         }
     }
 
@@ -70,33 +72,22 @@ public class Throw
 
 public abstract class ThrowEffect
 {
-    public virtual void ExecuteOnWin() { }
-    public virtual void ExecuteOnLose() { }
-    public virtual void ExecuteOnClash() { }
+    protected virtual void OnWin() { }
+    protected virtual void OnLose() { }
+    protected virtual void OnClash() { }
+    protected Player player;
+    protected Player opponent;
 
-    public ThrowEffect(ref EventHandler<Throw.ThrowOutcome> h) { h += Execute; }
-
-    private void Execute(Object sender, Throw.ThrowOutcome outcome)
-    {
-        if (outcome == Throw.ThrowOutcome.Won) ExecuteOnWin();
-        else if (outcome == Throw.ThrowOutcome.Lost) ExecuteOnLose();
-        else ExecuteOnClash();
-    }
-}
-
-public class TEffectDmgOnWin : ThrowEffect
-{
-    private int damage;
-    private Player opponent;
-
-    public TEffectDmgOnWin(
-            ref EventHandler<Throw.ThrowOutcome> h,
-            Player p_opponent,
-            int p_damage) : base(ref h)
-    {
-        damage = p_damage;
+    public ThrowEffect( Player p_player, Player p_opponent){
+        player = p_player;
         opponent = p_opponent;
     }
 
-    public override void ExecuteOnWin() { opponent.character.Damage(damage); }
+    public void Execute(ThrowOutcome outcome)
+    {
+        if (outcome == ThrowOutcome.Won) OnWin();
+        else if (outcome == ThrowOutcome.Lost) OnLose();
+        else OnClash();
+    }
 }
+

--- a/Assets/Scripts/Throw.cs
+++ b/Assets/Scripts/Throw.cs
@@ -78,7 +78,8 @@ public abstract class ThrowEffect
     protected Player player;
     protected Player opponent;
 
-    public ThrowEffect( Player p_player, Player p_opponent){
+    public ThrowEffect(Player p_player, Player p_opponent)
+    {
         player = p_player;
         opponent = p_opponent;
     }


### PR DESCRIPTION
Implement proper abstract base classes for `Character`, `Throw`, and `ThrowEffect`, instead of making them default to `Buster`, `Default <ThrowType>` and `TEffect_DmgOnWin` respectively.

Implement Buster, Default Rock/Paper/Scissors, and TEffect_DmgOnWin explicitly using the aforementioned abstract base classes

Remove the eventhandler implementation for ThrowEffects because I have no idea what I'm doing.  Going back to the old way of just iterating over throw effects and executing.